### PR TITLE
OntrackTrigger: make minimumResult configurable

### DIFF
--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackTrigger.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackTrigger.java
@@ -49,6 +49,11 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
     private final String parameterName;
 
     /**
+     * Minimum result of previous run
+     */
+    private final Result minimumResult;
+
+    /**
      * Constructor.
      *
      * @param spec          CRON specification
@@ -58,12 +63,15 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
      * @param parameterName Name of the parameter which contains the name of the build   @throws ANTLRException If CRON expression is not correct
      */
     @DataBoundConstructor
-    public OntrackTrigger(String spec, String project, String branch, String promotion, String parameterName) throws ANTLRException {
+    public OntrackTrigger(String spec, String project, String branch, String promotion, String parameterName, String minimumResult) throws ANTLRException {
         super(spec);
         this.project = project;
         this.branch = branch;
         this.promotion = promotion;
         this.parameterName = parameterName;
+        if(minimumResult==null||minimumResult.isEmpty()) minimumResult = "SUCCESS";
+        // if 'minimumResult' contains an invalid value, the fromString method will return Result.FAILURE
+        this.minimumResult = Result.fromString(minimumResult);
     }
 
     public String getProject() {
@@ -80,6 +88,10 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
 
     public String getParameterName() {
         return parameterName;
+    }
+
+    public Result getMinimumResult() {
+        return minimumResult;
     }
 
     @Override
@@ -134,7 +146,7 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
         Run lastBuild = job.getLastBuild();
         if (lastBuild != null) {
             Result result = lastBuild.getResult();
-            if (result == null || (result.isWorseThan(Result.SUCCESS) && result.isCompleteBuild())) {
+            if (result == null || (result.isWorseThan(minimumResult) && result.isCompleteBuild())) {
                 LOGGER.log(LOG_LEVEL, String.format("[ontrack][trigger][%s] Last build was failed or unsuccessful", job.getFullName()));
                 firing = true;
             } else {

--- a/src/main/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPoint.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPoint.java
@@ -14,8 +14,16 @@ public class OntrackTriggerContextExtensionPoint extends ContextExtensionPoint {
      * Trigger
      */
     @DslExtensionMethod(context = TriggerContext.class)
+    public OntrackTrigger ontrackTrigger(String spec, String project, String branch, String promotion, String parameterName, String minimumResult) throws ANTLRException {
+        return new OntrackTrigger(spec, project, branch, promotion, parameterName, minimumResult);
+    }
+
+    /**
+     * Trigger
+     */
+    @DslExtensionMethod(context = TriggerContext.class)
     public OntrackTrigger ontrackTrigger(String spec, String project, String branch, String promotion, String parameterName) throws ANTLRException {
-        return new OntrackTrigger(spec, project, branch, promotion, parameterName);
+        return new OntrackTrigger(spec, project, branch, promotion, parameterName, "SUCCESS");
     }
 
     /**

--- a/src/test/java/net/nemerosa/ontrack/jenkins/OntrackTriggerTest.java
+++ b/src/test/java/net/nemerosa/ontrack/jenkins/OntrackTriggerTest.java
@@ -6,28 +6,35 @@ import org.junit.Test;
 
 public class OntrackTriggerTest {
 
+    public static final String VALID_SPEC = "H H(2-5) * * *";
+    public static final String INVALID_SPEC = "H H(2-5)";
+    public static final String PROJECT = "project";
+    public static final String BRANCH = "branch";
+    public static final String PROMOTION = "promotion";
+    public static final String PARAMETER_NAME = "parameterName";
 
     @Test(expected = ANTLRException.class)
     public void invalid_cron_expression_results_in_exception() throws ANTLRException{
         OntrackTrigger trigger = new OntrackTrigger(
-                "H H(2-5)",
-                "project",
-                "branch",
-                "promotion",
-                "parameterName",
+                INVALID_SPEC,
+                PROJECT,
+                BRANCH,
+                PROMOTION,
+                PARAMETER_NAME,
                 null
         );
     }
-      @Test
-    public void default_result_is_success() {
+
+    @Test
+    public void default_result_is_success_for_null() {
         OntrackTrigger trigger = null;
         try {
             trigger = new OntrackTrigger(
-                    "H H(2-5) * * *",
-                    "project",
-                    "branch",
-                    "promotion",
-                    "parameterName",
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
                     null
             );
         } catch (ANTLRException e) {
@@ -37,17 +44,35 @@ public class OntrackTriggerTest {
         assert trigger.getMinimumResult() == Result.SUCCESS;
     }
 
+    @Test
+    public void default_result_is_success_for_empty() {
+        OntrackTrigger trigger = null;
+        try {
+            trigger = new OntrackTrigger(
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
+                    ""
+            );
+        } catch (ANTLRException e) {
+
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.SUCCESS;
+    }
 
     @Test
     public void invalid_result_becomes_failure() {
         OntrackTrigger trigger = null;
         try {
             trigger = new OntrackTrigger(
-                    "H H(2-5) * * *",
-                    "project",
-                    "branch",
-                    "promotion",
-                    "parameterName",
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
                     "BROL"
             );
         } catch (ANTLRException e) {
@@ -62,11 +87,11 @@ public class OntrackTriggerTest {
         OntrackTrigger trigger = null;
         try {
             trigger = new OntrackTrigger(
-                    "H H(2-5) * * *",
-                    "project",
-                    "branch",
-                    "promotion",
-                    "parameterName",
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
                     "UNSTABLE"
             );
         } catch (ANTLRException e) {

--- a/src/test/java/net/nemerosa/ontrack/jenkins/OntrackTriggerTest.java
+++ b/src/test/java/net/nemerosa/ontrack/jenkins/OntrackTriggerTest.java
@@ -1,0 +1,78 @@
+package net.nemerosa.ontrack.jenkins;
+
+import antlr.ANTLRException;
+import hudson.model.Result;
+import org.junit.Test;
+
+public class OntrackTriggerTest {
+
+
+    @Test(expected = ANTLRException.class)
+    public void invalid_cron_expression_results_in_exception() throws ANTLRException{
+        OntrackTrigger trigger = new OntrackTrigger(
+                "H H(2-5)",
+                "project",
+                "branch",
+                "promotion",
+                "parameterName",
+                null
+        );
+    }
+      @Test
+    public void default_result_is_success() {
+        OntrackTrigger trigger = null;
+        try {
+            trigger = new OntrackTrigger(
+                    "H H(2-5) * * *",
+                    "project",
+                    "branch",
+                    "promotion",
+                    "parameterName",
+                    null
+            );
+        } catch (ANTLRException e) {
+
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.SUCCESS;
+    }
+
+
+    @Test
+    public void invalid_result_becomes_failure() {
+        OntrackTrigger trigger = null;
+        try {
+            trigger = new OntrackTrigger(
+                    "H H(2-5) * * *",
+                    "project",
+                    "branch",
+                    "promotion",
+                    "parameterName",
+                    "BROL"
+            );
+        } catch (ANTLRException e) {
+
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.FAILURE;
+    }
+
+    @Test
+    public void valid_result_is_used() {
+        OntrackTrigger trigger = null;
+        try {
+            trigger = new OntrackTrigger(
+                    "H H(2-5) * * *",
+                    "project",
+                    "branch",
+                    "promotion",
+                    "parameterName",
+                    "UNSTABLE"
+            );
+        } catch (ANTLRException e) {
+
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.UNSTABLE;
+    }
+}

--- a/src/test/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPointTest.java
+++ b/src/test/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPointTest.java
@@ -1,0 +1,28 @@
+package net.nemerosa.ontrack.jenkins.extension;
+
+import antlr.ANTLRException;
+import hudson.model.Result;
+import net.nemerosa.ontrack.jenkins.OntrackTrigger;
+import org.junit.Test;
+
+public class OntrackTriggerContextExtensionPointTest {
+
+    @Test
+    public void test(){
+        OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
+        OntrackTrigger trigger = null;
+        try {
+            trigger = extensionPoint.ontrackTrigger(
+                    "H H(2-5) * * *",
+                    "project",
+                    "name",
+                    "promotion",
+                    "parameterName",
+                    "UNSTABLE"
+            );
+        } catch (ANTLRException e) {
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.UNSTABLE;
+    }
+}

--- a/src/test/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPointTest.java
+++ b/src/test/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPointTest.java
@@ -7,22 +7,105 @@ import org.junit.Test;
 
 public class OntrackTriggerContextExtensionPointTest {
 
+    public static final String VALID_SPEC = "H H(2-5) * * *";
+    public static final String INVALID_SPEC = "H H(2-5)";
+    public static final String PROJECT = "project";
+    public static final String BRANCH = "branch";
+    public static final String PROMOTION = "promotion";
+    public static final String PARAMETER_NAME = "parameterName";
+
     @Test
-    public void test(){
+    public void set_custom_minimum_result(){
         OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
         OntrackTrigger trigger = null;
         try {
             trigger = extensionPoint.ontrackTrigger(
-                    "H H(2-5) * * *",
-                    "project",
-                    "name",
-                    "promotion",
-                    "parameterName",
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
                     "UNSTABLE"
             );
         } catch (ANTLRException e) {
             e.printStackTrace();
         }
         assert trigger.getMinimumResult() == Result.UNSTABLE;
+    }
+
+
+    @Test
+    public void invalid_value_results_in_failure(){
+        OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
+        OntrackTrigger trigger = null;
+        try {
+            trigger = extensionPoint.ontrackTrigger(
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
+                    "BROL"
+            );
+        } catch (ANTLRException e) {
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.FAILURE;
+    }
+
+    @Test
+    public void default_value_is_success_for_null(){
+        OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
+        OntrackTrigger trigger = null;
+        try {
+            trigger = extensionPoint.ontrackTrigger(
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
+                    null
+            );
+        } catch (ANTLRException e) {
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.SUCCESS;
+    }
+
+    @Test
+    public void default_value_is_success_for_empty(){
+        OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
+        OntrackTrigger trigger = null;
+        try {
+            trigger = extensionPoint.ontrackTrigger(
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME,
+                    ""
+            );
+        } catch (ANTLRException e) {
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.SUCCESS;
+    }
+
+    @Test
+    public void default_value_is_success_if_missing_parameter(){
+        OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
+        OntrackTrigger trigger = null;
+        try {
+            trigger = extensionPoint.ontrackTrigger(
+                    VALID_SPEC,
+                    PROJECT,
+                    BRANCH,
+                    PROMOTION,
+                    PARAMETER_NAME
+            );
+        } catch (ANTLRException e) {
+            e.printStackTrace();
+        }
+        assert trigger.getMinimumResult() == Result.SUCCESS;
     }
 }


### PR DESCRIPTION
When using OntrackTrigger to schedule builds to run on a certain promotion, the build will always rerun on the same version if no new promotion was found, but the latest result was 'worse than SUCCESS'

Making this 'minimumResult' configurable, will allow users to avoid rerunning Failed or Unstable builds, by setting this parameter to e.g. 'FAILURE' or 'UNSTABLE'

When using 'UNSTABLE' the build will only rerun if the previous run was worse, i.e. FAILURE (or ABORTED, ...)
When using 'FAILURE' the build will only rerun if the previous run was worse, i.e. ABORTED, ...
Failed builds will not be rerun in that case.