### PR TITLE
Feature/ontrack trigger syntax fix

### DIFF
--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackTrigger.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackTrigger.java
@@ -27,6 +27,7 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
     private static final Logger LOGGER = Logger.getLogger(OntrackTrigger.class.getName());
 
     private static final Level LOG_LEVEL = Level.FINE;
+    public static final String SUCCESS = "SUCCESS";
 
     /**
      * Ontrack project name
@@ -51,7 +52,7 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
     /**
      * Minimum result of previous run
      */
-    private final Result minimumResult;
+    private final String minimumResult;
 
     /**
      * Constructor.
@@ -69,9 +70,7 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
         this.branch = branch;
         this.promotion = promotion;
         this.parameterName = parameterName;
-        if(minimumResult==null||minimumResult.isEmpty()) minimumResult = "SUCCESS";
-        // if 'minimumResult' contains an invalid value, the fromString method will return Result.FAILURE
-        this.minimumResult = Result.fromString(minimumResult);
+        this.minimumResult = minimumResult!=null?minimumResult:SUCCESS;
     }
 
     public String getProject() {
@@ -90,7 +89,7 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
         return parameterName;
     }
 
-    public Result getMinimumResult() {
+    public String getMinimumResult() {
         return minimumResult;
     }
 
@@ -146,7 +145,8 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
         Run lastBuild = job.getLastBuild();
         if (lastBuild != null) {
             Result result = lastBuild.getResult();
-            if (result == null || (result.isWorseThan(minimumResult) && result.isCompleteBuild())) {
+            Result minimum = Result.fromString(minimumResult);
+            if (result == null || (result.isWorseThan(minimum) && result.isCompleteBuild())) {
                 LOGGER.log(LOG_LEVEL, String.format("[ontrack][trigger][%s] Last build was failed or unsuccessful", job.getFullName()));
                 firing = true;
             } else {

--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackTrigger.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackTrigger.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,6 +29,8 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
 
     private static final Level LOG_LEVEL = Level.FINE;
     public static final String SUCCESS = "SUCCESS";
+    public static final String FAILURE = "FAILURE";
+    public static final String UNSTABLE = "UNSTABLE";
 
     /**
      * Ontrack project name
@@ -61,7 +64,9 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
      * @param project       Ontrack project
      * @param branch        Ontrack branch
      * @param promotion     Ontrack promotion
-     * @param parameterName Name of the parameter which contains the name of the build   @throws ANTLRException If CRON expression is not correct
+     * @param parameterName Name of the parameter which contains the name of the build
+     * @param minimumResult Minimum Result of the previous build
+     * @throws ANTLRException If CRON expression is not correct
      */
     @DataBoundConstructor
     public OntrackTrigger(String spec, String project, String branch, String promotion, String parameterName, String minimumResult) throws ANTLRException {
@@ -70,7 +75,11 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
         this.branch = branch;
         this.promotion = promotion;
         this.parameterName = parameterName;
-        this.minimumResult = minimumResult!=null?minimumResult:SUCCESS;
+        // First we parse the given String 'minimumResult'
+        // Hence 'minimumResult' will be
+        // - 'SUCCESS' if the input is null or an empty String
+        // - 'FAILURE' if the input contains an invalid value
+        this.minimumResult = (minimumResult!=null&&!minimumResult.isEmpty())?Result.fromString(minimumResult).toString():SUCCESS;
     }
 
     public String getProject() {
@@ -91,6 +100,14 @@ public class OntrackTrigger extends Trigger<AbstractProject> {
 
     public String getMinimumResult() {
         return minimumResult;
+    }
+
+    public List<String> getChoices(){
+        List<String> list = new ArrayList<>();
+        list.add(SUCCESS);
+        list.add(UNSTABLE);
+        list.add(FAILURE);
+        return list;
     }
 
     @Override

--- a/src/main/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPoint.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPoint.java
@@ -23,7 +23,7 @@ public class OntrackTriggerContextExtensionPoint extends ContextExtensionPoint {
      */
     @DslExtensionMethod(context = TriggerContext.class)
     public OntrackTrigger ontrackTrigger(String spec, String project, String branch, String promotion, String parameterName) throws ANTLRException {
-        return new OntrackTrigger(spec, project, branch, promotion, parameterName, "SUCCESS");
+        return ontrackTrigger(spec, project, branch, promotion, parameterName, null);
     }
 
     /**

--- a/src/main/resources/net/nemerosa/ontrack/jenkins/OntrackTrigger/config.jelly
+++ b/src/main/resources/net/nemerosa/ontrack/jenkins/OntrackTrigger/config.jelly
@@ -18,7 +18,7 @@
     <f:entry name="minimumResult" title="Minimum Result" field="minimumResult">
         <select name="minimumResult">
             <j:forEach var="key" items="${instance.choices}">
-                <f:option value="${key}">${key}</f:option>
+                <f:option value="${key}" selected="${key==instance.minimumResult}">${key}</f:option>
             </j:forEach>
         </select>
     </f:entry>

--- a/src/main/resources/net/nemerosa/ontrack/jenkins/OntrackTrigger/config.jelly
+++ b/src/main/resources/net/nemerosa/ontrack/jenkins/OntrackTrigger/config.jelly
@@ -15,7 +15,11 @@
     <f:entry title="Parameter name" field="parameterName" default="VERSION">
         <f:textbox />
     </f:entry>
-    <f:entry title="Minimum Result" field="minimumResult" default="SUCCESS">
-        <f:textbox />
+    <f:entry name="minimumResult" title="Minimum Result" field="minimumResult">
+        <select name="minimumResult">
+            <f:option value="SUCCESS">SUCCESS</f:option>
+            <f:option value="UNSTABLE">UNSTABLE</f:option>
+            <f:option value="FAILURE">FAILURE</f:option>
+        </select>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/net/nemerosa/ontrack/jenkins/OntrackTrigger/config.jelly
+++ b/src/main/resources/net/nemerosa/ontrack/jenkins/OntrackTrigger/config.jelly
@@ -17,9 +17,9 @@
     </f:entry>
     <f:entry name="minimumResult" title="Minimum Result" field="minimumResult">
         <select name="minimumResult">
-            <f:option value="SUCCESS">SUCCESS</f:option>
-            <f:option value="UNSTABLE">UNSTABLE</f:option>
-            <f:option value="FAILURE">FAILURE</f:option>
+            <j:forEach var="key" items="${instance.choices}">
+                <f:option value="${key}">${key}</f:option>
+            </j:forEach>
         </select>
     </f:entry>
 </j:jelly>

--- a/src/test/java/net/nemerosa/ontrack/jenkins/OntrackTriggerTest.java
+++ b/src/test/java/net/nemerosa/ontrack/jenkins/OntrackTriggerTest.java
@@ -1,7 +1,6 @@
 package net.nemerosa.ontrack.jenkins;
 
 import antlr.ANTLRException;
-import hudson.model.Result;
 import org.junit.Test;
 
 public class OntrackTriggerTest {
@@ -34,7 +33,7 @@ public class OntrackTriggerTest {
 
             e.printStackTrace();
         }
-        assert trigger.getMinimumResult() == Result.SUCCESS;
+        assert trigger.getMinimumResult() == OntrackTrigger.SUCCESS;
     }
 
 
@@ -54,7 +53,7 @@ public class OntrackTriggerTest {
 
             e.printStackTrace();
         }
-        assert trigger.getMinimumResult() == Result.FAILURE;
+        assert trigger.getMinimumResult() == OntrackTrigger.FAILURE;
     }
 
     @Test
@@ -73,6 +72,6 @@ public class OntrackTriggerTest {
 
             e.printStackTrace();
         }
-        assert trigger.getMinimumResult() == Result.UNSTABLE;
+        assert trigger.getMinimumResult() == OntrackTrigger.UNSTABLE;
     }
 }

--- a/src/test/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPointTest.java
+++ b/src/test/java/net/nemerosa/ontrack/jenkins/extension/OntrackTriggerContextExtensionPointTest.java
@@ -1,14 +1,34 @@
 package net.nemerosa.ontrack.jenkins.extension;
 
 import antlr.ANTLRException;
-import hudson.model.Result;
 import net.nemerosa.ontrack.jenkins.OntrackTrigger;
 import org.junit.Test;
 
 public class OntrackTriggerContextExtensionPointTest {
 
     @Test
-    public void test(){
+    public void minimumResultIsFailureForInvalidInput(){
+        testMinimumResult("BROL", OntrackTrigger.FAILURE);
+    }
+
+    @Test
+    public void minimumResultIsSuccessForEmptyInput(){
+        testMinimumResult("", OntrackTrigger.SUCCESS);
+    }
+
+    @Test
+    public void minimumResultIsSuccessForNullInput(){
+        testMinimumResult(null, OntrackTrigger.SUCCESS);
+    }
+
+    @Test
+    public void useValidValuesForMinimumResult(){
+        testMinimumResult(OntrackTrigger.SUCCESS, OntrackTrigger.SUCCESS);
+        testMinimumResult(OntrackTrigger.UNSTABLE, OntrackTrigger.UNSTABLE);
+        testMinimumResult(OntrackTrigger.FAILURE, OntrackTrigger.FAILURE);
+    }
+
+    public void testMinimumResult(String givenResult, String expectedResult){
         OntrackTriggerContextExtensionPoint extensionPoint = new OntrackTriggerContextExtensionPoint();
         OntrackTrigger trigger = null;
         try {
@@ -18,11 +38,11 @@ public class OntrackTriggerContextExtensionPointTest {
                     "name",
                     "promotion",
                     "parameterName",
-                    "UNSTABLE"
+                    givenResult
             );
         } catch (ANTLRException e) {
             e.printStackTrace();
         }
-        assert trigger.getMinimumResult() == Result.UNSTABLE;
+        assert trigger.getMinimumResult() == expectedResult;
     }
 }


### PR DESCRIPTION
Now the OntrackTrigger uses the **minimumResult** as String i.s.o. Result.
The **index.jelly** page shows a fixed list (SUCCESS, UNSTABLE, FAILURE) which comes from the code itself (getChoices() method).
Changing the selected option in this config page is reflected in the job config file (config.xml) and when reloading the config file page, the correct option is selected in the dropdownList.