### PR TITLE
add support for declarative pipeline parameters

### DIFF
--- a/JOB_COMPONENTS.md
+++ b/JOB_COMPONENTS.md
@@ -58,6 +58,20 @@ Enter a DSL which returns one object and extracts a property of this
 object using the _Value property_ field. The resulting string will
 be used as the value for the parameter.
 
+In [Declarative Pipeline Syntax](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline), parameters can be specified as in the example below,
+
+```groovy
+    parameters {
+        ontrackSingleParam(name: 'RELEASE_NUMBER', description: 'Release number', dsl: "ontrack.branch('PRJ', 'BRANCH')", valueProperty: 'name')
+    }
+```
+
+and then used as in the example below.
+
+```groovy
+    params.RELEASE_NUMBER
+```
+
 ### Parameter choice
 
 The DSL can be used to allow the selection among a list of values
@@ -69,6 +83,20 @@ Enter a DSL which returns a list of objects (a single object would
    be converted into a singleton list) and extracts a property of
    each item using the _Value property_ field. The resulting list of
    strings is then used for the selection.
+
+In [Declarative Pipeline Syntax](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline), parameters can be specified as in the example below,
+
+```groovy
+    parameters {
+        ontrackChoiceParam(name: 'RELEASE_NUMBER', description: 'Release number', dsl: "ontrack.branch('PRJ', 'BRANCH').standardFilter(count: 5)", valueProperty: 'name')
+    }
+```
+
+and then used as in the example below.
+
+```groovy
+    params.RELEASE_NUMBER
+```
 
 ### Run condition
 

--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackChoiceParameterDefinition.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackChoiceParameterDefinition.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -54,6 +55,7 @@ public class OntrackChoiceParameterDefinition extends AbstractOntrackMultiplePar
     }
 
     @Extension
+    @Symbol("ontrackChoiceParam")
     public static class DescriptorImpl extends ParameterDescriptor {
 
         @Override

--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackMultiChoiceParameterDefinition.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackMultiChoiceParameterDefinition.java
@@ -5,6 +5,7 @@ import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -49,6 +50,7 @@ public class OntrackMultiChoiceParameterDefinition extends AbstractOntrackMultip
     }
 
     @Extension
+    @Symbol("ontrackMultiChoiceParam")
     public static class DescriptorImpl extends ParameterDescriptor {
 
         @Override

--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackSingleParameterDefinition.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackSingleParameterDefinition.java
@@ -5,6 +5,7 @@ import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 import net.nemerosa.ontrack.jenkins.dsl.DSLRunner;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -51,6 +52,7 @@ public class OntrackSingleParameterDefinition extends AbstractOntrackParameterDe
     }
 
     @Extension
+    @Symbol("ontrackSingleParam")
     public static class DescriptorImpl extends ParameterDescriptor {
 
         @Override


### PR DESCRIPTION
Implements #40 and completes #19 
add support for declarative pipeline parameters (docs : https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline)

cc @dcoraboeuf 