### PR TITLE
Fix ClassCastException in OntrackMultiChoiceParameter

### DIFF
--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackMultiChoiceParameterDefinition.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackMultiChoiceParameterDefinition.java
@@ -34,7 +34,7 @@ public class OntrackMultiChoiceParameterDefinition extends AbstractOntrackMultip
             JSONArray jsonArray = (JSONArray) object;
             for (int i = 0; i < choices.size(); i++) {
                 String choice = choices.get(i);
-                if ((Boolean) jsonArray.get(i)) {
+                if (i < jsonArray.size() && jsonArray.get(i) instanceof Boolean && (Boolean) jsonArray.get(i)){
                     selectionList.add(choice);
                 }
             }

--- a/src/main/java/net/nemerosa/ontrack/jenkins/OntrackMultiChoiceParameterDefinition.java
+++ b/src/main/java/net/nemerosa/ontrack/jenkins/OntrackMultiChoiceParameterDefinition.java
@@ -21,13 +21,22 @@ public class OntrackMultiChoiceParameterDefinition extends AbstractOntrackMultip
 
     @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
-        JSONArray jsonArray = (JSONArray)jo.get("value");
+        Object object = jo.get("value");
         List<String> choices = getChoices();
         List<String> selectionList = new ArrayList<>();
-        for(int i=0;i<choices.size();i++){
-            String choice = choices.get(i);
-            if((Boolean)jsonArray.get(i)){
-                selectionList.add(choice);
+        if(object instanceof Boolean && !choices.isEmpty()){
+            Boolean selected = (Boolean) object;
+            String firstOption = choices.get(0);
+            if(selected){
+                selectionList.add(firstOption);
+            }
+        } else if (object instanceof JSONArray) {
+            JSONArray jsonArray = (JSONArray) object;
+            for (int i = 0; i < choices.size(); i++) {
+                String choice = choices.get(i);
+                if ((Boolean) jsonArray.get(i)) {
+                    selectionList.add(choice);
+                }
             }
         }
         String selections = StringUtils.join(selectionList, ',');


### PR DESCRIPTION
If the OntrackMultiChoiceParameter displays only one option, we get a ClassCastException, because this option is passed as a single Boolean, while we expected a JSONArray of Booleans.

With this fix we first verify the object type and handle it differently in case of a Boolean.
This has been tested ok locally.